### PR TITLE
Add snackbar to be used for the errors of register and login #14

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,25 +21,26 @@
     }
   },
   "dependencies": {
-    "nuxt": "^2.0.0",
     "@nuxtjs/axios": "^5.3.6",
-    "@nuxtjs/pwa": "^3.0.0-0"
+    "@nuxtjs/pwa": "^3.0.0-0",
+    "@snackbar/core": "^1.7.0",
+    "nuxt": "^2.0.0"
   },
   "devDependencies": {
-    "@nuxtjs/tailwindcss": "^1.0.0",
     "@nuxtjs/eslint-config": "^1.0.1",
     "@nuxtjs/eslint-module": "^1.0.0",
-    "babel-eslint": "^10.0.1",
-    "eslint": "^6.1.0",
-    "eslint-plugin-nuxt": ">=0.4.2",
-    "eslint-config-prettier": "^4.1.0",
-    "eslint-plugin-prettier": "^3.0.1",
-    "prettier": "^1.16.4",
-    "husky": "^2.6.0",
-    "lint-staged": "^8.2.1",
+    "@nuxtjs/tailwindcss": "^1.0.0",
     "@vue/test-utils": "^1.0.0-beta.27",
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^24.1.0",
+    "eslint": "^6.1.0",
+    "eslint-config-prettier": "^4.1.0",
+    "eslint-plugin-nuxt": ">=0.4.2",
+    "eslint-plugin-prettier": "^3.0.1",
+    "husky": "^2.6.0",
     "jest": "^24.1.0",
+    "lint-staged": "^8.2.1",
+    "prettier": "^1.16.4",
     "vue-jest": "^4.0.0-0"
   }
 }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -168,6 +168,8 @@
 
 <script>
 import Axios from 'axios'
+import { createSnackbar } from '@snackbar/core'
+import '@snackbar/core/dist/snackbar.css'
 import Header from '~/components/Header.vue'
 import Footer from '~/components/Footer.vue'
 
@@ -197,12 +199,16 @@ export default {
         password: this.login_password
       })
         .then(function(_response) {
-          alert(`You have logged in!`)
+          createSnackbar(`You have logged in!`, {
+            position: 'right'
+          })
         })
         .catch(function(error) {
           // eslint-disable-next-line
           console.log(error.response.data.errors)
-          alert(`Something went wrong! Check your browser logs!`)
+          createSnackbar(`Something went wrong! Check your browser logs!`, {
+            position: 'right'
+          })
         })
     },
     register() {
@@ -212,12 +218,16 @@ export default {
         password_confirmation: this.register_password_confirmation
       })
         .then(function(_response) {
-          alert(`You have registered!`)
+          createSnackbar(`You have registered!`, {
+            position: 'right'
+          })
         })
         .catch(function(error) {
           // eslint-disable-next-line
           console.log(error.response.data.errors)
-          alert(`Something went wrong! Check your browser logs!`)
+          createSnackbar(`Something went wrong! Check your browser logs!`, {
+            position: 'right'
+          })
         })
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1186,6 +1186,11 @@
   dependencies:
     any-observable "^0.3.0"
 
+"@snackbar/core@^1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@snackbar/core/-/core-1.7.0.tgz#a12708f2df8dbb0f8de885b8460c94ab3f659333"
+  integrity sha512-CxBEpC/boiGc0PGASQSYU4YmPFkyBhki8n2uJad593VlHcISJjgMMoD1Kk/sdqkEYxKF9zx64aY5F/fP1VfCjg==
+
 "@types/babel__core@^7.1.0":
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.3.tgz#e441ea7df63cd080dfcd02ab199e6d16a735fc30"


### PR DESCRIPTION
# Story Title

[Add snackbar to be used for the errors of register and login](https://github.com/kuru-project/main-website-client/issues/14)

# Changes made

- Install Snackbar (by egoist)
- Import Snackbar to main page
- Use Snackbar instead of alert messages

# How does the solution address the problem

This PR will add, install and make use of Snackbar by egoist.
