### PR TITLE
Change localhost:8000 to localhost:3000 and NuxtJS to NextJS at README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ $ cp sample.env .env
 # install dependencies
 $ yarn install
 
-# serve with hot reload at localhost:8000
+# serve with hot reload at localhost:3000
 $ yarn dev
 
 # build for production and launch server
@@ -21,7 +21,7 @@ $ yarn build
 $ yarn start
 ```
 
-For detailed explanation on how things work, check out [Nuxt.js docs](https://nuxtjs.org).
+For detailed explanation on how things work, check out [Next.js docs](https://nextjs.org).
 
 ## Contributors ✨
 


### PR DESCRIPTION
# Story Title

[Yarn dev starts at localhost:3000 instead of localhost:8000](https://github.com/kuru-project/main-website-client/issues/54)

# Changes made

- Change localhost:8000 to localhost:3000 and NuxtJS to NextJS at README.md

# How does the solution address the problem

I changed the localhost:8000 to localhost:3000 and the typo error of NextJS at README.md