### PR TITLE
Add page title to the index page

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,5 +1,13 @@
+import Head from 'next/head'
+
 function HomePage() {
-  return <div>Welcome to Next.js!</div>
+  return (
+    <div>
+      <Head>
+        <title>Kuru Anime Title</title>
+      </Head>
+    </div>
+  )
 }
 
 export default HomePage


### PR DESCRIPTION
# Story Title

[Add page title to the index page](https://github.com/kuru-project/main-website-client/issues/52)

# Changes made

- Add page title to the `index` page with a name of Kuru Anime

# How does the solution address the problem

Add page title to the index page with a name of Kuru Anime
