### PR TITLE
Create a Header and a Footer component and put it inside Next's main layout #45

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,8 +1,8 @@
 function Footer() {
   return (
-    <>
+    <footer>
       footer
-    </>
+    </footer>
   )
 }
 

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,0 +1,9 @@
+function Footer() {
+  return (
+    <>
+      footer
+    </>
+  )
+}
+
+export default Footer

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,0 +1,9 @@
+function Header() {
+  return (
+    <>
+      header
+    </>
+  )
+}
+
+export default Header

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,8 +1,8 @@
 function Header() {
   return (
-    <>
+    <header>
       header
-    </>
+    </header>
   )
 }
 

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,0 +1,27 @@
+// import App from 'next/app'
+import Header from '../components/Header';
+import Footer from '../components/Footer';
+
+function MyApp({ Component, pageProps }) {
+  return (
+    <>
+      <Header />
+      <Component {...pageProps} />
+      <Footer />
+    </>
+  )
+}
+
+// Only uncomment this method if you have blocking data requirements for
+// every single page in your application. This disables the ability to
+// perform automatic static optimization, causing every page in your app to
+// be server-side rendered.
+//
+// MyApp.getInitialProps = async (appContext) => {
+//   // calls page's `getInitialProps` and fills `appProps.pageProps`
+//   const appProps = await App.getInitialProps(appContext);
+//
+//   return { ...appProps }
+// }
+
+export default MyApp

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -6,6 +6,9 @@ function HomePage() {
       <Head>
         <title>Kuru Anime Title</title>
       </Head>
+      <div>
+        Under Maintenance
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
# Story Title

[Create a Header and a Footer component and put it inside Next's main layout](https://github.com/kuru-project/main-website-client/issues/45)

# Changes made

- Create `_app.tsx`
- Create components directory
- Create Header and Footer components
- Import Header and Footer on `_app.tsx`
- Add **Under Maintenance** to the index.tsx

# How does the solution address the problem

This PR will add a Header and a Footer component to the App section.
