### PR TITLE
Create a simple Navigation on the Header #49

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,9 +1,11 @@
 import SocialMedia from './SocialMedia';
+import Navigation from './Navigation';
 
 function Footer() {
   return (
     <footer>
       footer
+      <Navigation />
       <SocialMedia />
     </footer>
   )

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,9 +1,11 @@
 import SocialMedia from './SocialMedia';
+import Navigation from './Navigation';
 
 function Header() {
   return (
     <header>
       header
+      <Navigation />
       <SocialMedia />
     </header>
   )

--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -1,0 +1,17 @@
+import Link from 'next/link'
+
+function Navigation() {
+  return (
+    <ul>
+      <li><Link href="/"><a>Home</a></Link></li>
+      <li><Link href="/about"><a>About Us</a></Link></li>
+      <li><Link href="/opensource"><a>Open Source</a></Link></li>
+      <li><Link href="/mission"><a>Mission</a></Link></li>
+      <li><Link href="/vision"><a>Vision</a></Link></li>
+      <li><Link href="/team"><a>Team</a></Link></li>
+      <li><Link href="/rules/discord"><a>Discord Rules</a></Link></li>
+    </ul>
+  )
+}
+
+export default Navigation

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -1,5 +1,16 @@
+import Head from 'next/head'
+
 function AboutPage() {
-  return <div>Welcome to Next.js!</div>
+  return (
+    <div>
+      <Head>
+        <title>About Us - Kuru Anime</title>
+      </Head>
+      <div>
+        About Us
+      </div>
+    </div>
+  )
 }
 
 export default AboutPage

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -4,10 +4,10 @@ function HomePage() {
   return (
     <div>
       <Head>
-        <title>Kuru Anime Title</title>
+        <title>Kuru Anime - Anime Social Network</title>
       </Head>
       <div>
-        Under Maintenance
+        Homepage
       </div>
     </div>
   )

--- a/pages/mission.tsx
+++ b/pages/mission.tsx
@@ -1,5 +1,16 @@
+import Head from 'next/head'
+
 function MissionPage() {
-  return <div>Mission Page</div>
+  return (
+    <div>
+      <Head>
+        <title>Mission - Kuru Anime</title>
+      </Head>
+      <div>
+        Mission
+      </div>
+    </div>
+  )
 }
 
 export default MissionPage

--- a/pages/opensource.tsx
+++ b/pages/opensource.tsx
@@ -1,5 +1,16 @@
+import Head from 'next/head'
+
 function OpenSourcePage() {
-  return <div>Open Source Page</div>
+  return (
+    <div>
+      <Head>
+        <title>Open Source - Kuru Anime</title>
+      </Head>
+      <div>
+        Open Source
+      </div>
+    </div>
+  )
 }
 
 export default OpenSourcePage

--- a/pages/rules/discord.tsx
+++ b/pages/rules/discord.tsx
@@ -1,5 +1,16 @@
+import Head from 'next/head'
+
 function RulesDiscordPage() {
-  return <div>Welcome to Next.js!</div>
+  return (
+    <div>
+      <Head>
+        <title>Discord Rules - Kuru Anime</title>
+      </Head>
+      <div>
+        Discord Rules
+      </div>
+    </div>
+  )
 }
 
 export default RulesDiscordPage

--- a/pages/team.tsx
+++ b/pages/team.tsx
@@ -1,5 +1,16 @@
+import Head from 'next/head'
+
 function TeamPage() {
-  return <div>Team Page</div>
+  return (
+    <div>
+      <Head>
+        <title>Team - Kuru Anime</title>
+      </Head>
+      <div>
+        Team
+      </div>
+    </div>
+  )
 }
 
 export default TeamPage

--- a/pages/vision.tsx
+++ b/pages/vision.tsx
@@ -1,5 +1,16 @@
+import Head from 'next/head'
+
 function VisionPage() {
-  return <div>Vision Page</div>
+  return (
+    <div>
+      <Head>
+        <title>Vision - Kuru Anime</title>
+      </Head>
+      <div>
+        Vision
+      </div>
+    </div>
+  )
 }
 
 export default VisionPage


### PR DESCRIPTION
# Story Title

[Create a simple Navigation on the Header](https://github.com/kuru-project/main-website-client/issues/49)

# Changes made

- Create `Navigation` component
- Import `Navigation` on Footer and Header component
- Import next/link on `Navigation`
- Link all the pages on `Navigation`
- Make a clear distinction between pages by adding next/head to each page

# How does the solution address the problem

This PR will add navigation on the Header and sitemap on the Footer
